### PR TITLE
Also accept Vite 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "react": ">=16",
-    "vite": "^2 || ^3 || ^4"
+    "vite": "^2 || ^3 || ^4 || ^5"
   },
   "devDependencies": {
     "@arnaud-barre/eslint-config": "^1.0.19",


### PR DESCRIPTION
As I can confirm `vite-plugin-react-click-to-component` works properly with Vite 5, I think the peer dependency can be relaxed to accept it.