### PR TITLE
change from fetch to window.location.assign

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -106,7 +106,11 @@ window.addEventListener("contextmenu", (event) => {
     spanR.textContent = layer.path.replace(`${root}/`, "");
     item.appendChild(spanR);
     item.addEventListener("click", () => {
-      void fetch(`/__open-in-editor?file=${encodeURIComponent(layer.path)}`);
+      const url = getUrl({
+        editor: "vscode",
+        pathToSource: layer.path,
+      });
+      window.location.assign(url);
       cleanUp();
     });
     menuElement.appendChild(item);
@@ -200,3 +204,13 @@ const getReactInstanceForElement = (element: Element): Fiber | undefined => {
     if (key.startsWith("__reactFiber")) return (element as any)[key];
   }
 };
+
+function getUrl({
+  editor,
+  pathToSource,
+}: {
+  editor: string;
+  pathToSource: string;
+}) {
+  return `${editor}://file${pathToSource}`;
+}


### PR DESCRIPTION
It wasn't working in the docker container.

Switching to `window.location.assign` fixed it for me.

This is what the OG react-click-to-component uses.

https://github.com/ericclemmons/click-to-component/blob/main/packages/click-to-react-component/src/ClickToComponent.js#L70

I was expecting to have to set a `REALPWD` or something of the sort. I didn't have to, not sure, it just knew.